### PR TITLE
fix: Broadcast proper payload for flag_contradiction events

### DIFF
--- a/src/p2p/memory_client.py
+++ b/src/p2p/memory_client.py
@@ -113,11 +113,17 @@ class P2PMemoryClient:
         result = await fn(**args)
 
         # After local observe/claim/flag_contradiction, broadcast event to network
-        if method in ("observe", "claim", "flag_contradiction"):
+        if method in ("observe", "claim"):
             await self._node._broadcast_event(method, {
                 "id": result,
                 "source": args.get("source", ""),
                 "text": args.get("text", ""),
+            })
+        elif method == "flag_contradiction":
+            await self._node._broadcast_event(method, {
+                "stmt_id_1": args["stmt_id_1"],
+                "stmt_id_2": args["stmt_id_2"],
+                "reason": args.get("reason", ""),
             })
 
         return result


### PR DESCRIPTION
## Summary
- Fix empty event payloads for `flag_contradiction` by building a dedicated broadcast payload with `stmt_id_1`, `stmt_id_2`, and `reason`
- Add `flag_contradiction` → `contradiction` mapping in the UI bridge so events display with correct label and content
- Resolves #1

## Test plan
- [x] All 185 non-LLM tests pass
- [ ] Run `make dev`, trigger contradicting observations, verify "CON" label with statement IDs appears in UI event stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)